### PR TITLE
StaticConfigTrait::getConfig($key) return type

### DIFF
--- a/StaticConfigTrait.php
+++ b/StaticConfigTrait.php
@@ -110,7 +110,7 @@ trait StaticConfigTrait
      * Reads existing configuration.
      *
      * @param string $key The name of the configuration.
-     * @return array|null Array of configuration data.
+     * @return array|mixed|null Configuration data.
      */
     public static function getConfig($key)
     {


### PR DESCRIPTION
StaticConfigTrait::getConfig($key) may return int/string/float, not only array for single key
